### PR TITLE
Added authorisation mekasm

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
 # lexShop-back
 DB
+AUTHORISATION

--- a/services/src/authorization-service/handler.js
+++ b/services/src/authorization-service/handler.js
@@ -1,0 +1,5 @@
+import { basicAuthorizer } from './handlers/basicAuthorizer';
+
+export {
+    basicAuthorizer,
+}

--- a/services/src/authorization-service/handlers/basicAuthorizer.js
+++ b/services/src/authorization-service/handlers/basicAuthorizer.js
@@ -1,0 +1,29 @@
+'use strict';
+
+import {
+    lambdaLogger
+} from '../../utils/lambda-logger';
+import { generatePolicy } from '../utils/generate-policy';
+
+const logger = lambdaLogger();
+
+export const basicAuthorizer = (event, ctx, cb) => {
+  logger.log('Auth event:', event);
+  if (event.type !== 'TOKEN') {
+    return cb('Unauthorized');
+  }
+  try {
+    const encodedCreds = event.authorizationToken.split(' ')[1];
+    const [username, password] = Buffer.from(encodedCreds, 'base64').toString('utf-8').split(':');
+    logger.log('username', username);
+    logger.log('password', password);
+    const userPassword = process.env[username]
+    const effect = !userPassword || userPassword !== password ? 'Deny' : 'Allow';
+    logger.log('Auth effect', effect);
+    const policy = generatePolicy(encodedCreds, event.methodArn, effect);
+    logger.log('Auth policy', policy);
+    cb(null, policy);
+  } catch (e) {
+    logger.error('Auth error:', e);
+  }
+}

--- a/services/src/authorization-service/package-lock.json
+++ b/services/src/authorization-service/package-lock.json
@@ -1,0 +1,71 @@
+{
+  "name": "authorization-service",
+  "version": "1.0.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "requires": {
+        "color-convert": "^2.0.1"
+      }
+    },
+    "chalk": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+      "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+      "requires": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      }
+    },
+    "color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "requires": {
+        "color-name": "~1.1.4"
+      }
+    },
+    "color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+    },
+    "dotenv": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-8.2.0.tgz",
+      "integrity": "sha512-8sJ78ElpbDJBHNeBzUbUVLsqKdccaa/BXF1uPTw3GrvQTBgrQrtObr2mUrE38vzYd8cEv+m/JBfDLioYcfXoaw=="
+    },
+    "dotenv-expand": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/dotenv-expand/-/dotenv-expand-5.1.0.tgz",
+      "integrity": "sha512-YXQl1DSa4/PQyRfgrv6aoNjhasp/p4qs9FjJ4q4cQk+8m4r6k4ZSiEyytKG8f8W9gi8WsQtIObNmKd+tMzNTmA=="
+    },
+    "has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
+    },
+    "serverless-dotenv-plugin": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/serverless-dotenv-plugin/-/serverless-dotenv-plugin-3.1.0.tgz",
+      "integrity": "sha512-R9Jld4a/hDDd0lHiSq9xQuFlhtfgXqKKmODrYp7115iQ9kgf16SMxZbxJ0Cb9GqL6/4+5GlS42iHxsqv8GxZeQ==",
+      "requires": {
+        "chalk": "^4.1.0",
+        "dotenv": "^8.2.0",
+        "dotenv-expand": "^5.1.0"
+      }
+    },
+    "supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "requires": {
+        "has-flag": "^4.0.0"
+      }
+    }
+  }
+}

--- a/services/src/authorization-service/package.json
+++ b/services/src/authorization-service/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "authorization-service",
+  "version": "1.0.0",
+  "description": "Authorization-service (API based)",
+  "main": "handler.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "get-swagger-documentation": "serverless downloadDocumentation --outputFileName=swagger.ext",
+    "deploy": "sls deploy"
+  },
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+  },
+  "devDependencies": {
+    "aws-sdk": "^2.792.0",
+    "@babel/cli": "^7.12.1",
+    "@babel/core": "^7.12.3",
+    "@babel/node": "^7.12.6",
+    "@babel/preset-env": "^7.12.1",
+    "serverless-aws-documentation": "^1.1.0",
+    "serverless-webpack": "^5.3.5",
+    "webpack": "^4.44.1",
+    "webpack-node-externals": "^2.5.0"
+  }
+}

--- a/services/src/authorization-service/serverless.yml
+++ b/services/src/authorization-service/serverless.yml
@@ -1,0 +1,26 @@
+service: authorization-service
+
+provider:
+  name: aws
+  runtime: nodejs12.x
+  stage: dev
+  region: eu-west-1
+
+resources:
+  Outputs:
+    basicAuthorizerArn:
+      Value:
+        'Fn::GetAtt': ['BasicAuthorizerLambdaFunction', 'Arn']                
+
+plugins:
+  - serverless-webpack
+  - serverless-aws-documentation
+
+custom:
+  webpack:
+    webpackConfig: '../../webpack.config.js'
+    includeModules: true
+
+functions:
+  basicAuthorizer:
+    handler: handler.basicAuthorizer

--- a/services/src/authorization-service/utils/generate-policy.js
+++ b/services/src/authorization-service/utils/generate-policy.js
@@ -1,0 +1,11 @@
+export const generatePolicy = (principalId, resource, effect) => ({
+      principalId,
+      policyDocument: {
+        Version: '2012-10-17',
+        Statement: [{
+          Action: ['execute-api:Invoke'],
+          Effect: effect,
+          Resource: [resource]
+        }]
+      }
+  });

--- a/services/src/import-service/handlers/import-products-file.js
+++ b/services/src/import-service/handlers/import-products-file.js
@@ -1,4 +1,4 @@
-import  AWS  from 'aws-sdk';
+import AWS from 'aws-sdk';
 const BUCKET = 'task-5-lex';
 import {
   lambdaLogger
@@ -11,15 +11,17 @@ export const importProductsFile = async event => {
   const productsName = event.queryStringParameters.name;
   const productsPath = `productsFiles/${productsName}`;
 
-  const s3 = new AWS.S3({region: 'eu-west-1'});
+  const s3 = new AWS.S3({
+    region: 'eu-west-1'
+  });
   const params = {
     Bucket: BUCKET,
     Key: productsPath,
     Expires: 60,
   }
 
-    return new Promise((resolve, reject)=>{ 
-      s3.getSignedUrl('putObject', params, (error, url)=>{
+  return new Promise((resolve, reject) => {
+    s3.getSignedUrl('putObject', params, (error, url) => {
       if (error) {
         return reject(error);
       }
@@ -27,7 +29,11 @@ export const importProductsFile = async event => {
 
       resolve({
         statusCode: 200,
-        headers: {"Access-Control-Allow-Origin": "*" },
+        headers: {
+          'Access-Control-Allow-Origin': '*',
+          'Access-Control-Allow-Credentials': 'true',
+          'Access-Control-Allow-Headers': '*',
+        },
         body: url
       })
     })

--- a/services/src/import-service/serverless.yml
+++ b/services/src/import-service/serverless.yml
@@ -25,7 +25,7 @@ provider:
     SQS_URL:
       Ref: SQSQueue
     SNS_ARN:
-      Ref: SNSTopic        
+      Ref: SNSTopic
 
 resources:
   Resources:
@@ -56,7 +56,41 @@ resources:
           event:
             - product-published-failed
         TopicArn:
-          Ref: SNSTopic
+          Ref: SNSTopic          
+    GatewayResponseAccessDenied:
+      Type: AWS::ApiGateway::GatewayResponse
+      Properties:
+        RestApiId:
+          Ref: 'ApiGatewayRestApi'
+        ResponseType: 'ACCESS_DENIED'
+        ResponseParameters:
+          gatewayresponse.header.Access-Control-Allow-Origin: "'*'"
+          gatewayresponse.header.Access-Control-Allow-Headers: "'*'"
+          gatewayresponse.header.Access-Control-Allow-Credentials: "'true'"
+          gatewayresponse.header.Access-Control-Allow-Methods: "'POST, GET, OPTIONS, PUT'"
+    GatewayResponseUnauthorized:
+      Type: AWS::ApiGateway::GatewayResponse
+      Properties:
+        RestApiId:
+          Ref: 'ApiGatewayRestApi'
+        ResponseType: 'UNAUTHORIZED'
+        ResponseParameters:
+          gatewayresponse.header.Access-Control-Allow-Origin: "'*'"
+          gatewayresponse.header.Access-Control-Allow-Headers: "'*'"
+          gatewayresponse.header.Access-Control-Allow-Credentials: "'true'"
+          gatewayresponse.header.Access-Control-Allow-Methods: "'POST, GET, OPTIONS, PUT'"
+    MissingAuthToken:
+      Type: AWS::ApiGateway::GatewayResponse
+      Properties:
+        RestApiId:
+          Ref: 'ApiGatewayRestApi'
+        ResponseType: 'MISSING_AUTHENTICATION_TOKEN'
+        ResponseParameters:
+          gatewayresponse.header.Access-Control-Allow-Origin: "'*'"
+          gatewayresponse.header.Access-Control-Allow-Headers: "'*'"
+          gatewayresponse.header.Access-Control-Allow-Credentials: "'true'"
+          gatewayresponse.header.Access-Control-Allow-Methods: "'POST, GET, OPTIONS, PUT'"
+            
              
 
 plugins:
@@ -89,6 +123,12 @@ functions:
       - http:
           path: import
           method: get
+          authorizer:
+              name: 'basicAuthorizer'
+              type: 'token'
+              arn: '${cf:authorization-service-${self:provider.stage}.basicAuthorizerArn}'
+              resultTtlInSeconds: 0
+              identitySource: 'method.request.header.Authorization'
   catalogParse:
     handler: handler.catalogParse
     events:


### PR DESCRIPTION
All tasks including additional ones were done.

1 - authorization-service is added to the repo, has correct basicAuthorizer lambda and correct serverless.ts file
3 - import-service serverless.ts file has authorizer configuration for the importProductsFile lambda.
5 - client application updated to send Authorization: Basic authorization_token header on import. Client gets authorization_token value from browser localStorage authorization_token = localStorage.getItem('authorization_token')
Additional tasks:

+1 - Client application display alerts for the responses in 401 and 403 HTTP statuses.

https://github.com/lexBogos/nodejs-aws-fe/pull/1 FE MR

Cloudfront link: https://d1sv461iq579q4.cloudfront.net/admin/products

Total 5.5/6 the issue is discrubed in the frontend MR.